### PR TITLE
Fix syntax errors in AWS CodeDeploy resource docs.

### DIFF
--- a/website/source/docs/providers/aws/r/codedeploy_app.html.markdown
+++ b/website/source/docs/providers/aws/r/codedeploy_app.html.markdown
@@ -2,7 +2,7 @@
 layout: "aws"
 page_title: "AWS: aws_codedeploy_app"
 sidebar_current: "docs-aws-resource-codedeploy-app"
-description: |\
+description: |-
   Provides a CodeDeploy application.
 ---
 

--- a/website/source/docs/providers/aws/r/codedeploy_deployment_group.html.markdown
+++ b/website/source/docs/providers/aws/r/codedeploy_deployment_group.html.markdown
@@ -2,7 +2,7 @@
 layout: "aws"
 page_title: "AWS: aws_codedeploy_deployment_group"
 sidebar_current: "docs-aws-resource-codedeploy-deployment-group"
-description: |\
+description: |-
   Provides a CodeDeploy deployment group.
 ---
 


### PR DESCRIPTION
(cherry picked from commit 932f0ddbeb598531f96ab2b7c29c87e6bb46cdef)terraform